### PR TITLE
DD-1362. Multiple inboxes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>easy-mirror-deposit</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
 
     <name>EASY Mirror Deposit</name>
     <url>https://github.com/DANS-KNAW/easy-mirror-deposit</url>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -19,17 +19,19 @@ taskQueue:
   keepAliveTime: 60 seconds
 
 mirroringService:
-  inbox: '/var/opt/dans.knaw.nl/tmp/transfer-inboxes/archaeology'
+  inboxes:
+    - path: '/var/opt/dans.knaw.nl/tmp/transfer-inboxes/archaeology'
+      #
+      # DVEs with version > 1.0 AND schema:datePublished before the date configured below should be deleted with a warning
+      #
+      ignoreMigratedDatasetUpdatesPublishedBefore: '2022-06-22'
+
   pollingInterval: 1000
   workDir: '/var/opt/dans.knaw.nl/tmp/easy-mirror-deposit-working-directory'
   depositOutbox: '/var/opt/dans.knaw.nl/tmp/easy-ingest-flow-inbox'
   failedBox: '/var/opt/dans.knaw.nl/tmp/easy-mirror-deposit-failed'
   easyMirrorStore: '/data/easy-mirror-store'
   velocityProperties: '/etc/opt/dans.knaw.nl/easy-mirror-deposit/velocity.properties'
-  #
-  # DVEs with version > 1.0 AND schema:datePublished before the date configured below should be deleted with a warning
-  #
-  ignoreMigratedDatasetUpdatesPublishedBefore: '2022-06-22'
 
 #
 # See https://www.dropwizard.io/en/latest/manual/configuration.html#logging

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -29,7 +29,7 @@ mirroringService:
       #
       # DVEs with version > 1.0 AND schema:datePublished before the date configured below should be deleted with a warning
       #
-      ignoreMigratedDatasetUpdatesPublishedBefore: '2023-05-01'
+      ignoreMigratedDatasetUpdatesPublishedBefore: '2023-06-01'
 
   pollingInterval: 1000
   workDir: '/var/opt/dans.knaw.nl/tmp/easy-mirror-deposit-working-directory'

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -25,6 +25,11 @@ mirroringService:
       # DVEs with version > 1.0 AND schema:datePublished before the date configured below should be deleted with a warning
       #
       ignoreMigratedDatasetUpdatesPublishedBefore: '2022-06-22'
+    - path: '/var/opt/dans.knaw.nl/tmp/transfer-inboxes/ssh'
+      #
+      # DVEs with version > 1.0 AND schema:datePublished before the date configured below should be deleted with a warning
+      #
+      ignoreMigratedDatasetUpdatesPublishedBefore: '2023-05-01'
 
   pollingInterval: 1000
   workDir: '/var/opt/dans.knaw.nl/tmp/easy-mirror-deposit-working-directory'

--- a/src/main/java/nl/knaw/dans/easy/mirror/EasyMirrorDepositApplication.java
+++ b/src/main/java/nl/knaw/dans/easy/mirror/EasyMirrorDepositApplication.java
@@ -44,7 +44,7 @@ public class EasyMirrorDepositApplication extends Application<EasyMirrorDepositC
             .build(taskExecutor, new TransferItemMetadataReaderImpl(environment.getObjectMapper(), new FileServiceImpl()));
         environment.lifecycle().manage(mirroringService);
         for (Inbox inbox : configuration.getMirroringService().getInboxes()) {
-            environment.healthChecks().register("Inbox", new InboxHealth(inbox.getPath()));
+            environment.healthChecks().register(String.format("Inbox-%s", inbox.getPath().toString()), new InboxHealth(inbox.getPath()));
         }
 
     }

--- a/src/main/java/nl/knaw/dans/easy/mirror/EasyMirrorDepositApplication.java
+++ b/src/main/java/nl/knaw/dans/easy/mirror/EasyMirrorDepositApplication.java
@@ -21,6 +21,7 @@ import io.dropwizard.setup.Environment;
 import nl.knaw.dans.easy.mirror.core.FileServiceImpl;
 import nl.knaw.dans.easy.mirror.core.MirroringService;
 import nl.knaw.dans.easy.mirror.core.TransferItemMetadataReaderImpl;
+import nl.knaw.dans.easy.mirror.core.config.Inbox;
 import nl.knaw.dans.easy.mirror.health.InboxHealth;
 
 import java.util.concurrent.ExecutorService;
@@ -42,7 +43,10 @@ public class EasyMirrorDepositApplication extends Application<EasyMirrorDepositC
         final MirroringService mirroringService = configuration.getMirroringService()
             .build(taskExecutor, new TransferItemMetadataReaderImpl(environment.getObjectMapper(), new FileServiceImpl()));
         environment.lifecycle().manage(mirroringService);
-        environment.healthChecks().register("Inbox", new InboxHealth(configuration.getMirroringService().getInbox()));
+        for (Inbox inbox : configuration.getMirroringService().getInboxes()) {
+            environment.healthChecks().register("Inbox", new InboxHealth(inbox.getPath()));
+        }
+
     }
 
 }

--- a/src/main/java/nl/knaw/dans/easy/mirror/MirroringServiceFactory.java
+++ b/src/main/java/nl/knaw/dans/easy/mirror/MirroringServiceFactory.java
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.mirror;
 
 import nl.knaw.dans.easy.mirror.core.MirroringService;
 import nl.knaw.dans.easy.mirror.core.TransferItemMetadataReader;
+import nl.knaw.dans.easy.mirror.core.config.Inbox;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -24,14 +25,14 @@ import java.nio.file.Path;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 public class MirroringServiceFactory {
-    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
     @NotNull
     @Valid
-    private Path inbox;
+    private List<Inbox> inboxes;
 
     private int pollingInterval;
 
@@ -55,21 +56,17 @@ public class MirroringServiceFactory {
     @Valid
     private Path velocityProperties;
 
-    @NotNull
-    @Valid
-    private Date ignoreMigratedDatasetUpdatesPublishedBefore;
-
     public MirroringService build(ExecutorService executorService, TransferItemMetadataReader transferItemMetadataReader) {
-        return new MirroringService(executorService, transferItemMetadataReader, velocityProperties, ignoreMigratedDatasetUpdatesPublishedBefore, pollingInterval, inbox, workDir,
+        return new MirroringService(executorService, transferItemMetadataReader, velocityProperties, pollingInterval, inboxes, workDir,
             depositOutbox, failedBox, easyMirrorStore);
     }
 
-    public Path getInbox() {
-        return inbox;
+    public List<Inbox> getInboxes() {
+        return inboxes;
     }
 
-    public void setInbox(Path inbox) {
-        this.inbox = inbox;
+    public void setInboxes(List<Inbox> inboxes) {
+        this.inboxes = inboxes;
     }
 
     public int getPollingInterval() {
@@ -120,16 +117,4 @@ public class MirroringServiceFactory {
         this.velocityProperties = velocityProperties;
     }
 
-    public Date getIgnoreMigratedDatasetUpdatesPublishedBefore() {
-        return ignoreMigratedDatasetUpdatesPublishedBefore;
-    }
-
-    public void setIgnoreMigratedDatasetUpdatesPublishedBefore(String date) {
-        try {
-            this.ignoreMigratedDatasetUpdatesPublishedBefore = dateFormat.parse(date);
-        }
-        catch (ParseException e) {
-            throw new IllegalArgumentException(e);
-        }
-    }
 }

--- a/src/main/java/nl/knaw/dans/easy/mirror/core/config/Inbox.java
+++ b/src/main/java/nl/knaw/dans/easy/mirror/core/config/Inbox.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.mirror.core.config;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class Inbox {
+    private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+
+    @NotNull
+    @Valid
+    private Path path;
+
+    @NotNull
+    @Valid
+    private Date ignoreMigratedDatasetUpdatesPublishedBefore;
+
+    public Path getPath() {
+        return path;
+    }
+
+    public void setPath(Path path) {
+        this.path = path;
+    }
+
+    public Date getIgnoreMigratedDatasetUpdatesPublishedBefore() {
+        return ignoreMigratedDatasetUpdatesPublishedBefore;
+    }
+
+    public void setIgnoreMigratedDatasetUpdatesPublishedBefore(String ignoreMigratedDatasetUpdatesPublishedBefore) {
+        try {
+            this.ignoreMigratedDatasetUpdatesPublishedBefore = dateFormat.parse(ignoreMigratedDatasetUpdatesPublishedBefore);
+        }
+        catch (ParseException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/src/main/java/nl/knaw/dans/easy/mirror/health/InboxHealth.java
+++ b/src/main/java/nl/knaw/dans/easy/mirror/health/InboxHealth.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class InboxHealth extends HealthCheck {
     private final Path inboxDir;
@@ -31,8 +32,11 @@ public class InboxHealth extends HealthCheck {
 
     @Override
     protected Result check() throws Exception {
-        try {
-            Files.list(inboxDir).collect(Collectors.toList());
+        try (Stream<Path> inboxFiles = Files.list(inboxDir)) {
+            String inboxFileNames = inboxFiles.map(Path::getFileName).map(Path::toString).collect(Collectors.joining(", "));
+            if (inboxFileNames.isEmpty()) {
+                return Result.unhealthy("Inbox is empty");
+            }
         }
         catch (IOException e) {
             return Result.unhealthy("Could not read inbox", e);


### PR DESCRIPTION
Fixes DD-1362

# Description of changes
Changes the configuration of `easy-mirror-deposit`, so that you can specify multiple inboxes to watch. Each inbox has its own `path` and `ignoreMigratedDatasetUpdatesPublishedBefore` settings.

# Related PRs
https://github.com/DANS-KNAW/dd-dtap/pull/332

# Notify

@DANS-KNAW/dataversedans
